### PR TITLE
Update Packer to v0.10.2

### DIFF
--- a/packer/packer.spec
+++ b/packer/packer.spec
@@ -1,13 +1,13 @@
 Name: packer
-Version: 0.10.0
+Version: 0.10.2
 Release: 1%{?dist}
 Summary: Create machine and container images for multiple platforms
 Group: Development/Tools
 License: MPLv2.0
 URL: https://www.packer.io/
 
-# Taken from https://releases.hashicorp.com/packer/0.10.0/packer_0.10.0_linux_amd64.zip
-Source0: packer_0.10.0_linux_amd64.zip
+# Taken from https://releases.hashicorp.com/packer/0.10.2/packer_0.10.2_linux_amd64.zip
+Source0: packer_0.10.2_linux_amd64.zip
 
 %description
 Packer is a tool for creating machine and container images for
@@ -30,6 +30,9 @@ popd
 %{_bindir}/*
 
 %changelog
+* Mon Oct 10 2016 Allan Lewis <allanlewis99@gmail.com> - 0.10.2-1
+- Update to 0.10.2
+
 * Thu May 05 2016 Josef Strzibny <strzibny@strzibny.name> - 0.10.0-1
 - Update to 0.10.0
 

--- a/packer/packer.spec
+++ b/packer/packer.spec
@@ -11,7 +11,7 @@ Source0: packer_0.10.2_linux_amd64.zip
 
 %description
 Packer is a tool for creating machine and container images for
-multiple platforms from a single source configuration. 
+multiple platforms from a single source configuration.
 
 %prep
 


### PR DESCRIPTION
This PR updates Packer to v0.10.2 and fixes a minor formatting issue in the '.spec' file.
